### PR TITLE
GPU対応版OpenCV 2.xを使うためのDockerfileを追加

### DIFF
--- a/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/.dockerignore
+++ b/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/.dockerignore
@@ -1,0 +1,2 @@
+build_image.sh
+run_bash.sh

--- a/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/Dockerfile
+++ b/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/Dockerfile
@@ -1,0 +1,50 @@
+FROM nvidia/cuda:8.0-devel-ubuntu16.04
+
+ENV NVIDIA_DRIVER_CAPABILITIES all
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    ffmpeg \
+    libavcodec-dev \
+    libavformat-dev \
+    libavresample-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libswscale-dev \
+    libtbb-dev \
+    libtiff-dev \
+    libv4l-dev \
+    pkg-config \
+    unzip \
+    wget \
+  && rm --recursive --force /var/lib/apt/lists/*
+ARG OPENCV_VERSION=2.4.13.7
+RUN mkdir -p /tmp/opencv \
+  && cd /tmp/opencv/ \
+  && wget --quiet https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip \
+  && unzip ${OPENCV_VERSION}.zip -d . \
+  && mkdir /tmp/opencv/opencv-${OPENCV_VERSION}/build \
+  && cd /tmp/opencv/opencv-${OPENCV_VERSION}/build/ \
+  && cmake \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_PERF_TESTS=OFF \
+    -D WITH_FFMPEG=ON \
+    -D WITH_TBB=ON \
+    -D WITH_CUDA=ON \
+    -D WITH_CUBLAS=ON \
+    -D WITH_NVCUVID=ON \
+    -D ENABLE_FAST_MATH=ON \
+    -D CUDA_FAST_MATH=ON \
+    -D CUDA_ARCH_BIN="6.1" \
+    -D CUDA_ARCH_PTX="6.1" \
+    -D CUDA_nvcuvid_LIBRARY=/usr/lib/x86_64-linux-gnu/libnvcuvid.so.1 \
+    .. \
+    | tee /tmp/opencv_cmake.log \
+  && make --jobs $(nproc) \
+    | tee /tmp/opencv_build.log \
+  && make install \
+    | tee /tmp/opencv_install.log \
+  && rm --recursive --force /tmp/opencv

--- a/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/README.md
+++ b/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/README.md
@@ -1,0 +1,5 @@
+# OpenCV 2.x
+
+## 参考
+
+* [nvidia-docker 2.x上でGPU対応版のOpenCV 2.xをビルド、インストールする - Qiita](https://qiita.com/yuyakato/items/75cfccb39544d5d7e269)

--- a/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/build_image.sh
+++ b/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/build_image.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+IMAGE_NAME=${USER}/opencv-2.x
+cd -- `dirname -- $0`
+docker build \
+  --tag ${IMAGE_NAME} \
+  .

--- a/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/run_bash.sh
+++ b/nvidia-cuda-8.0-devel-ubuntu-16.04/opencv-2.x/run_bash.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+IMAGE_NAME=${USER}/opencv-2.x
+docker run --interactive --tty --rm \
+  --volume $(pwd):/workspace \
+  ${IMAGE_NAME} \
+  /bin/bash


### PR DESCRIPTION
# 概要

GPU対応版OpenCV 2.xを使うための`Dockerfile`を追加しました。

# 関連

* Issue #7 過去に作成したDockerfileを追加する